### PR TITLE
feat(user/auth): added reset password endpoint

### DIFF
--- a/apps/main-service/src/domain/user/dto/reset-password.dto.ts
+++ b/apps/main-service/src/domain/user/dto/reset-password.dto.ts
@@ -1,0 +1,24 @@
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(3)
+  username: string;
+
+  @IsString()
+  @MinLength(6)
+  newPassword: string;
+
+  @IsString()
+  @MinLength(6)
+  confirmNewPassword: string;
+
+  @IsString()
+  firstName: string;
+
+  @IsString()
+  lastName: string;
+}

--- a/apps/main-service/src/domain/user/user.controller.ts
+++ b/apps/main-service/src/domain/user/user.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Put } from '@nestjs/common';
 import { User } from '@prisma/client';
 import { UserReq } from './../../common/decorator/user.decorator';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserService } from './user.service';
+import { Public } from '../../common/decorator/public.decorator';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 
 @Controller('/users')
 export class UserController {
@@ -15,5 +17,11 @@ export class UserController {
   @Get('/me')
   getMe(@UserReq() user: User) {
     return user;
+  }
+
+  @Public()
+  @Put('/reset-password')
+  resetPassword(@Body() data: ResetPasswordDto) {
+    return this.userService.resetPassword(data);
   }
 }


### PR DESCRIPTION
- Adds a public endpoint at PUT `/users/reset-password` that accepts the reset password request
- The password will only be reset if:
1. The email exists
2. The username matches the email
3. The firstName matches the record
4. The lastName matches the record
5. The new password and confirmation password match

This provides an additional layer of security by requiring users to know both their account details and personal information to reset their password.

- To use this endpoint, users would need to send a PUT request with a body like:

```
{
  "email": "user@example.com",
  "username": "username",
  "newPassword": "newpassword123",
  "confirmNewPassword": "newpassword123",
  "firstName": "John", 
  "lastName": "Doe"   
}
```

- Expected Responses:
1. Successful Response (200 OK):
```
{
    "id": "clxxxxxxxxxxxxxxx",
    "email": "your.email@example.com",
    "username": "yourusername",
    "firstName": "John",
    "lastName": "Doe"
}
```
2. Possible Error Responses:

2.1 If email doesn't exist (404 Not Found):
```
{
    "message": "No user found with this email",
    "error": "Not Found",
    "statusCode": 404
}
```

2.2 If username doesn't match email (400 Bad Request):
```
{
    "message": "Username does not match with the email",
    "error": "Bad Request",
    "statusCode": 400
}
```

2.3 If passwords don't match (400 Bad Request):
```
{
    "message": "Confirmed password must match the new password",
    "error": "Bad Request",
    "statusCode": 400
}
```

2.4 If firstName doesn't match (400 Bad Request):
```
{
    "message": "First name does not match our records",
    "error": "Bad Request",
    "statusCode": 400
}
```

2.5 If lastName doesn't match (400 Bad Request):
```
{
    "message": "Last name does not match our records",
    "error": "Bad Request",
    "statusCode": 400
}

```
