### PR TITLE
fix(user): removed requirement for reset-password

### DIFF
--- a/apps/main-service/src/domain/user/dto/reset-password.dto.ts
+++ b/apps/main-service/src/domain/user/dto/reset-password.dto.ts
@@ -15,10 +15,4 @@ export class ResetPasswordDto {
   @IsString()
   @MinLength(6)
   confirmNewPassword: string;
-
-  @IsString()
-  firstName: string;
-
-  @IsString()
-  lastName: string;
 }

--- a/apps/main-service/src/domain/user/user.service.ts
+++ b/apps/main-service/src/domain/user/user.service.ts
@@ -69,18 +69,8 @@ export class UserService {
       throw new BadRequestException('Username does not match with the email');
     }
 
-    if (user.firstName !== data.firstName) {
-      throw new BadRequestException('First name does not match our records');
-    }
-
-    if (user.lastName !== data.lastName) {
-      throw new BadRequestException('Last name does not match our records');
-    }
-
     if (data.newPassword !== data.confirmNewPassword) {
-      throw new BadRequestException(
-        'Confirmed password must match the new password',
-      );
+      throw new BadRequestException('Passwords do not match');
     }
 
     const hashedPassword = await this.hashPassword(data.newPassword);


### PR DESCRIPTION
- Adds a public endpoint at PUT `/users/reset-password` that accepts the reset password request
- The password will only be reset if:
1. The email exists
2. The username matches the email
3. The new password and confirmation password match

This provides an additional layer of security by requiring users to know both their account details and personal information to reset their password.

- To use this endpoint, users would need to send a PUT request with a body like:

```
{
  "email": "user@example.com",
  "username": "username",
  "newPassword": "newpassword123",
  "confirmNewPassword": "newpassword123"
}
```

- Expected Responses:
1. Successful Response (200 OK):
```
{
    "id": "clxxxxxxxxxxxxxxx",
    "email": "your.email@example.com",
    "username": "yourusername"
}
```
2. Possible Error Responses:

2.1 If email doesn't exist (404 Not Found):
```
{
    "message": "No user found with this email",
    "error": "Not Found",
    "statusCode": 404
}
```

2.2 If username doesn't match email (400 Bad Request):
```
{
    "message": "Username does not match with the email",
    "error": "Bad Request",
    "statusCode": 400
}
```

2.3 If passwords don't match (400 Bad Request):
```
{
    "message": "Confirmed password must match the new password",
    "error": "Bad Request",
    "statusCode": 400
}
