### PR TITLE
feat(property): add pagination to my properties endpoint

### DIFF
--- a/apps/main-service/src/domain/property/property.controller.ts
+++ b/apps/main-service/src/domain/property/property.controller.ts
@@ -199,6 +199,18 @@ export class PropertyController {
   }
 
   @ApiOperation({ summary: 'Get all properties owned by current user' })
+  @ApiQuery({
+    name: 'skip',
+    required: false,
+    type: Number,
+    description: 'Number of records to skip',
+  })
+  @ApiQuery({
+    name: 'take',
+    required: false,
+    type: Number,
+    description: 'Number of records to take',
+  })
   @ApiResponse({
     status: 200,
     description: 'Properties successfully retrieved',
@@ -242,8 +254,16 @@ export class PropertyController {
     description: 'Unauthorized - Invalid or missing token',
   })
   @Get('my')
-  getMyProperties(@UserReq() user: User) {
-    return this.propertyService.findAllByCreatorIdWithFullDetails(user.id);
+  getMyProperties(
+    @UserReq() user: User,
+    @Query('skip') skip?: number,
+    @Query('take') take?: number,
+  ) {
+    return this.propertyService.findAllByCreatorIdWithFullDetails(
+      user.id,
+      skip ? Number(skip) : undefined,
+      take ? Number(take) : undefined,
+    );
   }
 
   @ApiOperation({

--- a/apps/main-service/src/domain/property/property.service.ts
+++ b/apps/main-service/src/domain/property/property.service.ts
@@ -224,7 +224,11 @@ export class PropertyService {
     return property;
   }
 
-  async findAllByCreatorIdWithFullDetails(creatorId: string) {
+  async findAllByCreatorIdWithFullDetails(
+    creatorId: string,
+    skip?: number,
+    take?: number,
+  ) {
     return this.databaseService.property.findMany({
       where: {
         creatorId,
@@ -232,6 +236,8 @@ export class PropertyService {
       orderBy: {
         createdAt: 'desc',
       },
+      skip: skip || 0,
+      take: take || 10,
       include: {
         category: true,
         creator: {


### PR DESCRIPTION
- Add optional skip and take query parameters to GET /properties/my endpoint
- Update service method to handle pagination parameters
- Add Swagger documentation for pagination parameters
- Set default pagination values (skip: 0, take: 10)

This allows frontend clients to paginate through user's properties efficiently.