### PR TITLE
feat(api): implement API versioning (v1)

### DIFF
--- a/apps/main-service/src/domain/auth/auth.controller.ts
+++ b/apps/main-service/src/domain/auth/auth.controller.ts
@@ -6,7 +6,7 @@ import { CreateUserDto } from '../user/dto/create-user.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 
 @ApiTags('auth')
-@Controller('auth')
+@Controller({ path: '/auth', version: '1' })
 export class AuthController {
   constructor(private authService: AuthService) {}
 

--- a/apps/main-service/src/domain/category/category.controller.ts
+++ b/apps/main-service/src/domain/category/category.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import { CategoryService } from './category.service';
 import {
   ApiTags,
@@ -10,7 +10,7 @@ import {
 
 @ApiTags('categories')
 @ApiBearerAuth()
-@Controller('/categories')
+@Controller({ path: '/categories', version: '1' })
 export class CategoryController {
   constructor(private categoryService: CategoryService) {}
 

--- a/apps/main-service/src/domain/property/property.controller.ts
+++ b/apps/main-service/src/domain/property/property.controller.ts
@@ -28,7 +28,7 @@ import {
 
 @ApiTags('properties')
 @ApiBearerAuth()
-@Controller('properties')
+@Controller({ path: '/properties', version: '1' })
 export class PropertyController {
   constructor(private propertyService: PropertyService) {}
 

--- a/apps/main-service/src/domain/reservation/reservation.controller.ts
+++ b/apps/main-service/src/domain/reservation/reservation.controller.ts
@@ -27,7 +27,7 @@ import {
 
 @ApiTags('reservations')
 @ApiBearerAuth()
-@Controller('/reservations')
+@Controller({ path: '/reservations', version: '1' })
 @UseGuards(ReservationGuard)
 export class ReservationController {
   constructor(private reservationService: ReservationService) {}

--- a/apps/main-service/src/domain/user/user.controller.ts
+++ b/apps/main-service/src/domain/user/user.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/swagger';
 
 @ApiTags('users')
-@Controller('/users')
+@Controller({ path: '/users', version: '1' })
 export class UserController {
   constructor(private userService: UserService) {}
 

--- a/apps/main-service/src/health/health.controller.ts
+++ b/apps/main-service/src/health/health.controller.ts
@@ -4,7 +4,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { HealthResponseDto } from './dto/health-response.dto';
 
 @ApiTags('health')
-@Controller('/health')
+@Controller({ path: '/health', version: '1' })
 export class HealthController {
   @Public()
   @Get()


### PR DESCRIPTION
- Add API versioning support with backward compatibility
- Configure versioning to use URI-based version prefix (/api/v1/*)
- Set default version to '1' to maintain backward compatibility
- Update Swagger configuration to show versioned endpoints
- Add version '1' to all controllers:
  - AuthController
  - UserController
  - PropertyController
  - ReservationController
  - CategoryController
  - HealthController

Changes:
- main.ts: Add enableVersioning() with URI type and default version
- main.ts: Update Swagger config to show versioned paths
- Controllers: Update @Controller decorators with version '1'

This change ensures:
1. All API endpoints are now versioned
2. Existing clients continue to work via automatic redirection
3. API documentation reflects versioned endpoints
4. Future v2 endpoints can be added without breaking v1

Breaking Changes: None (backward compatible)