### PR TITLE
feat(throttler): implement rate limiting

### DIFF
--- a/apps/main-service/src/app.module.ts
+++ b/apps/main-service/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { DatabaseModule } from './database/database.module';
 import { DomainModule } from './domain/domain.module';
 import { AuthGuard } from './domain/guard/auth.guard';
@@ -7,7 +8,17 @@ import { HealthModule } from './health/health.module';
 import { SerializeInterceptor } from './interceptor/serialize.interceptor';
 
 @Module({
-  imports: [HealthModule, DatabaseModule, DomainModule],
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 50,
+      },
+    ]),
+    HealthModule,
+    DatabaseModule,
+    DomainModule,
+  ],
   providers: [
     {
       provide: APP_INTERCEPTOR,
@@ -16,6 +27,10 @@ import { SerializeInterceptor } from './interceptor/serialize.interceptor';
     {
       provide: APP_GUARD,
       useClass: AuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
     },
   ],
 })

--- a/apps/main-service/src/domain/auth/auth.controller.ts
+++ b/apps/main-service/src/domain/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { AuthService } from './auth.service';
 import { SignInDto } from './dto/sign-in.dto';
 import { CreateUserDto } from '../user/dto/create-user.dto';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('auth')
 @Controller({ path: '/auth', version: '1' })
@@ -33,6 +34,7 @@ export class AuthController {
     },
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @Public()
   @Post('sign-in')
   signIn(@Body() data: SignInDto) {
@@ -62,6 +64,7 @@ export class AuthController {
     },
   })
   @ApiResponse({ status: 400, description: 'Bad Request' })
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @Public()
   @Post('register')
   register(@Body() data: CreateUserDto) {

--- a/apps/main-service/src/domain/reservation/reservation.controller.ts
+++ b/apps/main-service/src/domain/reservation/reservation.controller.ts
@@ -24,6 +24,7 @@ import {
   ApiParam,
   ApiBody,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('reservations')
 @ApiBearerAuth()
@@ -120,6 +121,7 @@ export class ReservationController {
     description: 'Unauthorized - Invalid or missing token',
   })
   @ApiResponse({ status: 404, description: 'Not Found - Property not found' })
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @Post()
   create(@UserReq() user: User, @Body() data: CreateReservationDto) {
     data.userId = user.id;
@@ -130,6 +132,7 @@ export class ReservationController {
   @ApiOperation({ summary: 'Update a reservation' })
   @ApiParam({ name: 'reservationId', type: String })
   @ApiBody({ type: UpdateReservationDto })
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @Patch(':reservationId')
   updateById(
     @Param('reservationId') reservationId: string,

--- a/apps/main-service/src/domain/user/user.controller.ts
+++ b/apps/main-service/src/domain/user/user.controller.ts
@@ -11,6 +11,7 @@ import {
   ApiBody,
   ApiBearerAuth,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 
 @ApiTags('users')
 @Controller({ path: '/users', version: '1' })
@@ -63,6 +64,7 @@ export class UserController {
   })
   @ApiResponse({ status: 400, description: 'Bad Request' })
   @ApiResponse({ status: 404, description: 'User not found' })
+  @Throttle({ default: { limit: 3, ttl: 60000 } })
   @Public()
   @Put('/reset-password')
   resetPassword(@Body() data: ResetPasswordDto) {

--- a/apps/main-service/src/health/health.controller.ts
+++ b/apps/main-service/src/health/health.controller.ts
@@ -1,9 +1,11 @@
 import { Controller, Get } from '@nestjs/common';
 import { Public } from '../common/decorator/public.decorator';
+import { SkipThrottle } from '@nestjs/throttler';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { HealthResponseDto } from './dto/health-response.dto';
 
 @ApiTags('health')
+@SkipThrottle()
 @Controller({ path: '/health', version: '1' })
 export class HealthController {
   @Public()

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/swagger": "^8.0.7",
+    "@nestjs/throttler": "^6.2.1",
     "@prisma/client": "^5.21.1",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,6 +771,11 @@
   dependencies:
     tslib "2.5.3"
 
+"@nestjs/throttler@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/throttler/-/throttler-6.2.1.tgz#c241788a8b195e6c7c0cf94b1808c4cb940ac2fd"
+  integrity sha512-vdt6VjhKC6vcLBJRUb97IuR6Htykn5kokZzmT8+S5XFOLLjUF7rzRpr+nUOhK9pi1L0hhbzSf2v2FJl4v64EJA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
- Add global rate limiting with 50 requests per minute default
- Add stricter limits for sensitive endpoints:
  - Auth: 5 requests/min for sign-in and register
  - User: 3 requests/min for password reset
  - Reservation: 20 requests/min for create/update
- Skip rate limiting for health check endpoint