### PR TITLE
feat(property): add owner's property stats endpoint

### DIFF
--- a/apps/main-service/src/domain/property/property.controller.ts
+++ b/apps/main-service/src/domain/property/property.controller.ts
@@ -441,4 +441,35 @@ export class PropertyController {
   getFullPropertyById(@Param('propertyId') propertyId: string) {
     return this.propertyService.findByIdWithFullDetails(propertyId);
   }
+
+  @ApiOperation({
+    summary: "Get owner's property stats",
+    description:
+      'Returns aggregated stats for all properties owned by current user. ' +
+      'Stats include total number of properties, total nights booked, and total income from completed reservations. ' +
+      'Returns zeros if user has no properties.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Stats successfully retrieved',
+    schema: {
+      example: {
+        status: 200,
+        message: 'Success',
+        data: {
+          totalProperties: 5, // Returns 0 if no properties
+          totalNightsBookedFromAllProperties: 150, // Returns 0 if no completed reservations
+          totalIncomeFromAllProperties: 25000.0, // Returns 0 if no completed reservations
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Invalid or missing token',
+  })
+  @Get('my/stats')
+  getMyPropertyStats(@UserReq() user: User) {
+    return this.propertyService.getOwnerStats(user.id);
+  }
 }

--- a/apps/main-service/src/domain/property/property.service.ts
+++ b/apps/main-service/src/domain/property/property.service.ts
@@ -414,4 +414,26 @@ export class PropertyService {
 
     return propertiesWithDetails;
   }
+
+  async getOwnerStats(userId: string) {
+    // Reuse existing method to get all properties with their stats
+    const properties = await this.findAllByCreatorIdWithFullDetails(userId);
+
+    // Aggregate the stats
+    const totalNightsBookedFromAllProperties = properties.reduce(
+      (total, prop) => total + prop.totalNightsBooked,
+      0,
+    );
+
+    const totalIncomeFromAllProperties = properties.reduce(
+      (total, prop) => total + prop.totalIncome,
+      0,
+    );
+
+    return {
+      totalProperties: properties.length,
+      totalNightsBookedFromAllProperties,
+      totalIncomeFromAllProperties,
+    };
+  }
 }

--- a/apps/main-service/src/domain/reservation/reservation.controller.ts
+++ b/apps/main-service/src/domain/reservation/reservation.controller.ts
@@ -166,7 +166,8 @@ export class ReservationController {
     description:
       "Returns paginated list of user's reservations. " +
       'Can be filtered by status (upcoming/past/all) and ordered by creation date (newest first). ' +
-      'Upcoming: startDate >= today, Past: endDate < today',
+      'Upcoming: startDate >= today, Past: endDate < today. ' +
+      'Returns empty array if no reservations found.',
   })
   @ApiQuery({
     name: 'status',


### PR DESCRIPTION
- Add GET /properties/my/stats endpoint for aggregated property stats
- Add getOwnerStats method in PropertyService
- Reuse findAllByCreatorIdWithFullDetails for consistent stats calculation
- Add Swagger documentation for the new endpoint

Stats include:
- totalProperties
- totalNightsBookedFromAllProperties
- totalIncomeFromAllProperties

BREAKING CHANGE: None