### PR TITLE
test: add unit tests for core services

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,51 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](LICENSE).
+
+## Testing
+
+### Unit Tests
+
+```bash
+# run all tests
+$ yarn test
+
+# run tests in watch mode
+$ yarn test:watch
+
+# run tests with coverage
+$ yarn test:cov
+
+# run specific test file
+$ yarn test path/to/file.spec.ts
+# example:
+$ yarn test apps/main-service/src/domain/property/property.service.spec.ts
+```
+
+### Important Notes
+
+- Tests use mock database, so they won't affect your development/production database
+- Tests are located next to the files they test (e.g., `service.ts` -> `service.spec.ts`)
+- Use `jest.config.js` for test configuration
+- Coverage reports are generated in the `./coverage` directory
+
+### Writing Tests
+
+Basic test structure:
+
+```typescript
+describe('ServiceName', () => {
+  let service: ServiceName;
+  let mockContext: MockContext;
+
+  beforeEach(async () => {
+    const { module, mockContext: mc } = await createTestingModule([
+      ServiceName,
+    ]);
+    service = module.get<ServiceName>(ServiceName);
+    mockContext = mc;
+  });
+
+  // Your test cases here
+});
+```

--- a/apps/main-service/src/database/database.service.test.ts
+++ b/apps/main-service/src/database/database.service.test.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+
+export type Context = {
+  prisma: PrismaClient;
+};
+
+export type MockContext = {
+  prisma: DeepMockProxy<PrismaClient>;
+};
+
+export const createMockContext = (): MockContext => {
+  return {
+    prisma: mockDeep<PrismaClient>(),
+  };
+};

--- a/apps/main-service/src/domain/amenity/amenity.service.spec.ts
+++ b/apps/main-service/src/domain/amenity/amenity.service.spec.ts
@@ -1,0 +1,92 @@
+import { AmenityService } from './amenity.service';
+import { createTestingModule } from '../../test/test-utils';
+import { MockContext } from '../../database/database.service.test';
+import { AMENITIES } from './amenity.config';
+
+describe('AmenityService', () => {
+  let service: AmenityService;
+  let mockContext: MockContext;
+
+  beforeEach(async () => {
+    const { module, mockContext: mc } = await createTestingModule([
+      AmenityService,
+    ]);
+    service = module.get<AmenityService>(AmenityService);
+    mockContext = mc;
+  });
+
+  describe('initialization', () => {
+    it('should sync amenities on module init', async () => {
+      // Arrange
+      mockContext.prisma.amenity.findMany.mockResolvedValue([]);
+      mockContext.prisma.amenity.createMany.mockResolvedValue({ count: 2 });
+
+      // Act
+      await service.onModuleInit();
+
+      // Assert
+      expect(mockContext.prisma.amenity.createMany).toHaveBeenCalledWith({
+        data: AMENITIES,
+      });
+    });
+
+    it('should not duplicate existing amenities', async () => {
+      // Arrange
+      const existingAmenities = [
+        {
+          id: 'amen1',
+          name: 'wifi',
+          description: 'High-speed wifi',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockContext.prisma.amenity.findMany.mockResolvedValue(existingAmenities);
+
+      // Act
+      await service.onModuleInit();
+
+      // Assert
+      expect(mockContext.prisma.amenity.createMany).toHaveBeenCalledWith({
+        data: AMENITIES.filter((a) => a.name !== 'wifi'),
+      });
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return amenities with pagination', async () => {
+      // Arrange
+      const mockAmenities = [
+        {
+          id: 'amen1',
+          name: 'wifi',
+          description: 'High-speed wifi',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockContext.prisma.amenity.findMany.mockResolvedValue(mockAmenities);
+
+      // Act
+      const result = await service.findMany({ skip: 0, take: 10 });
+
+      // Assert
+      expect(result).toEqual(mockAmenities);
+      expect(mockContext.prisma.amenity.findMany).toHaveBeenCalledWith({
+        skip: 0,
+        take: 10,
+      });
+    });
+
+    it('should handle empty results', async () => {
+      // Arrange
+      mockContext.prisma.amenity.findMany.mockResolvedValue([]);
+
+      // Act
+      const result = await service.findMany({ skip: 0, take: 10 });
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/main-service/src/domain/auth/auth.service.spec.ts
+++ b/apps/main-service/src/domain/auth/auth.service.spec.ts
@@ -1,0 +1,145 @@
+import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+import { JwtService } from '@nestjs/jwt';
+import { createTestingModule } from '../../test/test-utils';
+import { UnauthorizedException, BadRequestException } from '@nestjs/common';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let userService: jest.Mocked<UserService>;
+  let jwtService: jest.Mocked<JwtService>;
+
+  beforeEach(async () => {
+    userService = {
+      findOneOrFailByEmail: jest.fn(),
+      comparePassword: jest.fn(),
+      create: jest.fn(),
+    } as any;
+
+    jwtService = {
+      signAsync: jest.fn(),
+    } as any;
+
+    const { module } = await createTestingModule([
+      AuthService,
+      {
+        provide: UserService,
+        useValue: userService,
+      },
+      {
+        provide: JwtService,
+        useValue: jwtService,
+      },
+    ]);
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  describe('signIn', () => {
+    it('should sign in user with valid credentials', async () => {
+      // Arrange
+      const mockUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'hashedPassword',
+        firstName: 'Test',
+        lastName: 'User',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      userService.findOneOrFailByEmail.mockResolvedValue(mockUser);
+      userService.comparePassword.mockResolvedValue(true);
+      jwtService.signAsync.mockResolvedValue('mock.jwt.token');
+
+      // Act
+      const result = await service.signIn('test@example.com', 'password123');
+
+      // Assert
+      expect(result).toEqual({
+        jwt: 'mock.jwt.token',
+        user: {
+          id: mockUser.id,
+          email: mockUser.email,
+          username: mockUser.username,
+          firstName: mockUser.firstName,
+          lastName: mockUser.lastName,
+        },
+      });
+    });
+
+    it('should throw UnauthorizedException for invalid password', async () => {
+      // Arrange
+      const mockUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'hashedPassword',
+        firstName: 'Test',
+        lastName: 'User',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      userService.findOneOrFailByEmail.mockResolvedValue(mockUser);
+      userService.comparePassword.mockResolvedValue(false);
+
+      // Act & Assert
+      await expect(
+        service.signIn('test@example.com', 'wrongpassword'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('register', () => {
+    it('should register new user with valid data', async () => {
+      // Arrange
+      const mockUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        username: 'testuser',
+        firstName: 'Test',
+        lastName: 'User',
+      };
+
+      userService.create.mockResolvedValue({
+        ...mockUser,
+        password: 'hashedPassword',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      jwtService.signAsync.mockResolvedValue('mock.jwt.token');
+
+      // Act
+      const result = await service.register({
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'password123',
+        password2: 'password123',
+        firstName: 'Test',
+        lastName: 'User',
+      });
+
+      // Assert
+      expect(result).toEqual({
+        jwt: 'mock.jwt.token',
+        user: mockUser,
+      });
+    });
+
+    it('should throw BadRequestException if passwords do not match', async () => {
+      // Act & Assert
+      await expect(
+        service.register({
+          email: 'test@example.com',
+          username: 'testuser',
+          password: 'password123',
+          password2: 'differentpassword',
+          firstName: 'Test',
+          lastName: 'User',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/apps/main-service/src/domain/category/category.service.spec.ts
+++ b/apps/main-service/src/domain/category/category.service.spec.ts
@@ -1,0 +1,94 @@
+import { CategoryService } from './category.service';
+import { createTestingModule } from '../../test/test-utils';
+import { MockContext } from '../../database/database.service.test';
+import { CATEGORIES } from './category.config';
+
+describe('CategoryService', () => {
+  let service: CategoryService;
+  let mockContext: MockContext;
+
+  beforeEach(async () => {
+    const { module, mockContext: mc } = await createTestingModule([
+      CategoryService,
+    ]);
+    service = module.get<CategoryService>(CategoryService);
+    mockContext = mc;
+  });
+
+  describe('initialization', () => {
+    it('should sync categories on module init', async () => {
+      // Arrange
+      mockContext.prisma.category.findMany.mockResolvedValue([]);
+      mockContext.prisma.category.createMany.mockResolvedValue({ count: 2 });
+
+      // Act
+      await service.onModuleInit();
+
+      // Assert
+      expect(mockContext.prisma.category.createMany).toHaveBeenCalledWith({
+        data: CATEGORIES,
+      });
+    });
+
+    it('should not duplicate existing categories', async () => {
+      // Arrange
+      const existingCategories = [
+        {
+          id: 'cat1',
+          name: 'cabin',
+          description: 'Cozy cabin',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockContext.prisma.category.findMany.mockResolvedValue(
+        existingCategories,
+      );
+
+      // Act
+      await service.onModuleInit();
+
+      // Assert
+      expect(mockContext.prisma.category.createMany).toHaveBeenCalledWith({
+        data: CATEGORIES.filter((c) => c.name !== 'cabin'),
+      });
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return categories with pagination', async () => {
+      // Arrange
+      const mockCategories = [
+        {
+          id: 'cat1',
+          name: 'cabin',
+          description: 'Cozy cabin',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+      mockContext.prisma.category.findMany.mockResolvedValue(mockCategories);
+
+      // Act
+      const result = await service.findMany({ skip: 0, take: 10 });
+
+      // Assert
+      expect(result).toEqual(mockCategories);
+      expect(mockContext.prisma.category.findMany).toHaveBeenCalledWith({
+        skip: 0,
+        take: 10,
+      });
+    });
+
+    it('should handle empty results', async () => {
+      // Arrange
+      mockContext.prisma.category.findMany.mockResolvedValue([]);
+
+      // Act
+      const result = await service.findMany({ skip: 0, take: 10 });
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/main-service/src/domain/property/property.service.spec.ts
+++ b/apps/main-service/src/domain/property/property.service.spec.ts
@@ -1,0 +1,286 @@
+import { PropertyService } from './property.service';
+import { createTestingModule } from '../../test/test-utils';
+import { MockContext } from '../../database/database.service.test';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Amenity } from '@prisma/client';
+
+describe('PropertyService', () => {
+  let service: PropertyService;
+  let mockContext: MockContext;
+
+  beforeEach(async () => {
+    const { module, mockContext: mc } = await createTestingModule([
+      PropertyService,
+    ]);
+    service = module.get<PropertyService>(PropertyService);
+    mockContext = mc;
+  });
+
+  describe('create', () => {
+    it('should create a property with valid data', async () => {
+      // Arrange
+      const mockCategory = {
+        id: 'cat1',
+        name: 'cabin',
+        description: 'test',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const mockProperty = {
+        id: 'prop1',
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'user1',
+        categoryId: 'cat1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        totalNightsBooked: 0,
+        totalIncome: 0,
+      };
+
+      mockContext.prisma.category.findUnique.mockResolvedValue(mockCategory);
+      mockContext.prisma.property.create.mockResolvedValue(mockProperty);
+
+      // Act
+      const result = await service.create({
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        categoryId: 'cat1',
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'user1',
+      });
+
+      // Assert
+      expect(result).toEqual(mockProperty);
+      expect(mockContext.prisma.category.findUnique).toHaveBeenCalledWith({
+        where: { id: 'cat1' },
+      });
+    });
+
+    it('should throw BadRequestException if category not found', async () => {
+      // Arrange
+      mockContext.prisma.category.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.create({
+          name: 'Test Property',
+          tagLine: 'Test tagline',
+          description: 'Test description',
+          price: 100,
+          categoryId: 'invalid_id',
+          coverUrl: 'http://test.com/image.jpg',
+          guests: 2,
+          bedrooms: 1,
+          beds: 1,
+          baths: 1,
+          countryCode: 'US',
+          creatorId: 'user1',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should validate and connect amenities if provided', async () => {
+      // Arrange
+      const mockCategory = {
+        id: 'cat1',
+        name: 'cabin',
+        description: 'test',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const mockAmenities: Amenity[] = [
+        {
+          id: 'amen1',
+          name: 'wifi',
+          description: 'High-speed wifi',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'amen2',
+          name: 'pool',
+          description: 'Swimming pool',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const mockProperty = {
+        id: 'prop1',
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'user1',
+        categoryId: 'cat1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        totalNightsBooked: 0,
+        totalIncome: 0,
+      };
+
+      mockContext.prisma.category.findUnique.mockResolvedValue(mockCategory);
+      mockContext.prisma.amenity.findMany.mockResolvedValue(mockAmenities);
+      mockContext.prisma.property.create.mockResolvedValue(mockProperty);
+
+      // Act
+      const result = await service.create({
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        categoryId: 'cat1',
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'user1',
+        amenityIds: ['amen1', 'amen2'],
+      });
+
+      // Assert
+      expect(result).toEqual(mockProperty);
+      expect(mockContext.prisma.amenity.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ['amen1', 'amen2'] } },
+      });
+    });
+  });
+
+  describe('findByIdPublic', () => {
+    it('should return property if found', async () => {
+      // Arrange
+      const mockProperty = {
+        id: 'prop1',
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        categoryId: 'cat1',
+        creatorId: 'user1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        totalNightsBooked: 0,
+        totalIncome: 0,
+        category: {
+          id: 'cat1',
+          name: 'cabin',
+          description: 'test',
+        },
+        creator: {
+          id: 'user1',
+          username: 'testuser',
+        },
+        amenities: [],
+      };
+
+      mockContext.prisma.property.findUnique.mockResolvedValue(mockProperty);
+
+      // Act
+      const result = await service.findByIdPublic('prop1');
+
+      // Assert
+      expect(result).toEqual({
+        ...mockProperty,
+        amenities: [],
+      });
+    });
+
+    it('should throw NotFoundException if property not found', async () => {
+      // Arrange
+      mockContext.prisma.property.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.findByIdPublic('invalid_id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findManyPublic', () => {
+    it('should return filtered properties', async () => {
+      // Arrange
+      const mockProperties = [
+        {
+          id: 'prop1',
+          name: 'Test Property',
+          tagLine: 'Test tagline',
+          description: 'Test description',
+          price: 100,
+          coverUrl: 'http://test.com/image.jpg',
+          guests: 2,
+          bedrooms: 1,
+          beds: 1,
+          baths: 1,
+          countryCode: 'US',
+          categoryId: 'cat1',
+          creatorId: 'user1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          totalNightsBooked: 0,
+          totalIncome: 0,
+          category: {
+            id: 'cat1',
+            name: 'cabin',
+            description: 'test',
+          },
+          amenities: [],
+          creator: {
+            id: 'user1',
+            username: 'testuser',
+          },
+        },
+      ];
+
+      mockContext.prisma.property.findMany.mockResolvedValue(mockProperties);
+
+      // Act
+      const result = await service.findManyPublic({
+        categoryName: 'cabin',
+        propertyName: 'Test',
+      });
+
+      // Assert
+      expect(result).toEqual(mockProperties);
+      expect(mockContext.prisma.property.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            category: { name: 'cabin' },
+            name: { contains: 'Test', mode: 'insensitive' },
+          },
+        }),
+      );
+    });
+  });
+});

--- a/apps/main-service/src/domain/reservation/reservation.service.spec.ts
+++ b/apps/main-service/src/domain/reservation/reservation.service.spec.ts
@@ -1,0 +1,314 @@
+import { ReservationService } from './reservation.service';
+import { PropertyService } from '../property/property.service';
+import { createTestingModule } from '../../test/test-utils';
+import { MockContext } from '../../database/database.service.test';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import dayjs from 'dayjs';
+
+describe('ReservationService', () => {
+  let service: ReservationService;
+  let mockContext: MockContext;
+  let propertyService: jest.Mocked<PropertyService>;
+
+  beforeEach(async () => {
+    propertyService = {
+      findByIdWithFullDetails: jest.fn(),
+    } as any;
+
+    const { module, mockContext: mc } = await createTestingModule([
+      ReservationService,
+      {
+        provide: PropertyService,
+        useValue: propertyService,
+      },
+    ]);
+
+    service = module.get<ReservationService>(ReservationService);
+    mockContext = mc;
+  });
+
+  describe('create', () => {
+    it('should create a reservation with valid data', async () => {
+      // Arrange
+      const mockProperty = {
+        id: 'prop1',
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 4,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'owner1',
+        categoryId: 'cat1',
+        totalNightsBooked: 0,
+        totalIncome: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        reservations: [],
+        amenities: [],
+        category: {
+          id: 'cat1',
+          name: 'cabin',
+          description: 'test',
+        },
+        creator: {
+          id: 'owner1',
+          email: 'owner@test.com',
+          username: 'owner',
+        },
+      };
+
+      const mockReservation = {
+        id: 'res1',
+        propertyId: 'prop1',
+        userId: 'user1',
+        startDate: '2024-04-01',
+        endDate: '2024-04-03',
+        totalPrice: 600,
+        numberOfGuests: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      propertyService.findByIdWithFullDetails.mockResolvedValue(mockProperty);
+      mockContext.prisma.reservation.create.mockResolvedValue(mockReservation);
+
+      // Act
+      const result = await service.create({
+        propertyId: 'prop1',
+        userId: 'user1',
+        startDate: '2024-04-01',
+        endDate: '2024-04-03',
+        numberOfGuests: 3,
+      });
+
+      // Assert
+      expect(result).toEqual(mockReservation);
+      expect(mockContext.prisma.reservation.create).toHaveBeenCalledWith({
+        data: {
+          propertyId: 'prop1',
+          userId: 'user1',
+          startDate: '2024-04-01',
+          endDate: '2024-04-03',
+          totalPrice: 600,
+          numberOfGuests: 3,
+        },
+      });
+    });
+
+    it('should throw BadRequestException if guests exceed property capacity', async () => {
+      // Arrange
+      const mockProperty = {
+        id: 'prop1',
+        name: 'Test Property',
+        tagLine: 'Test tagline',
+        description: 'Test description',
+        price: 100,
+        coverUrl: 'http://test.com/image.jpg',
+        guests: 2,
+        bedrooms: 1,
+        beds: 1,
+        baths: 1,
+        countryCode: 'US',
+        creatorId: 'owner1',
+        categoryId: 'cat1',
+        totalNightsBooked: 0,
+        totalIncome: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        reservations: [],
+        amenities: [],
+        category: {
+          id: 'cat1',
+          name: 'cabin',
+          description: 'test',
+        },
+        creator: {
+          id: 'owner1',
+          email: 'owner@test.com',
+          username: 'owner',
+        },
+      };
+
+      propertyService.findByIdWithFullDetails.mockResolvedValue(mockProperty);
+
+      // Act & Assert
+      await expect(
+        service.create({
+          propertyId: 'prop1',
+          userId: 'user1',
+          startDate: '2024-04-01',
+          endDate: '2024-04-03',
+          numberOfGuests: 3, // Trying to book for 3 guests
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return filtered reservations', async () => {
+      // Arrange
+      const mockReservations = [
+        {
+          id: 'res1',
+          propertyId: 'prop1',
+          userId: 'user1',
+          startDate: '2024-04-01',
+          endDate: '2024-04-03',
+          totalPrice: 600,
+          numberOfGuests: 3,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          property: {
+            name: 'Test Property',
+            price: 100,
+            coverUrl: 'http://test.com/image.jpg',
+            creator: {
+              id: 'owner1',
+              username: 'owner',
+              email: 'owner@test.com',
+            },
+          },
+          user: {
+            id: 'user1',
+            username: 'user',
+            email: 'user@test.com',
+          },
+        },
+      ];
+
+      mockContext.prisma.reservation.findMany.mockResolvedValue(
+        mockReservations,
+      );
+
+      // Act
+      const result = await service.findAll('prop1', undefined, 0, 10);
+
+      // Assert
+      expect(result).toEqual(mockReservations);
+      expect(mockContext.prisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { propertyId: 'prop1' },
+        }),
+      );
+    });
+
+    it('should filter by upcoming status', async () => {
+      // Arrange
+      const currentDate = dayjs().format('YYYY-MM-DD');
+      mockContext.prisma.reservation.findMany.mockResolvedValue([]);
+
+      // Act
+      await service.findAll(undefined, 'user1', 0, 10, 'upcoming');
+
+      // Assert
+      expect(mockContext.prisma.reservation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            userId: 'user1',
+            startDate: { gte: currentDate },
+          },
+        }),
+      );
+    });
+  });
+
+  describe('updateReservation', () => {
+    it('should update reservation with valid data', async () => {
+      // Arrange
+      const mockExistingReservation = {
+        id: 'res1',
+        propertyId: 'prop1',
+        userId: 'user1',
+        startDate: '2024-04-01',
+        endDate: '2024-04-03',
+        totalPrice: 600,
+        numberOfGuests: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        property: {
+          price: 100,
+          guests: 4,
+        },
+      };
+
+      const mockUpdatedReservation = {
+        ...mockExistingReservation,
+        numberOfGuests: 2,
+        totalPrice: 400,
+      };
+
+      mockContext.prisma.reservation.findUnique.mockResolvedValue(
+        mockExistingReservation,
+      );
+      mockContext.prisma.reservation.update.mockResolvedValue(
+        mockUpdatedReservation,
+      );
+
+      // Act
+      const result = await service.updateReservation('res1', 'user1', {
+        numberOfGuests: 2,
+      });
+
+      // Assert
+      expect(result).toEqual(mockUpdatedReservation);
+    });
+
+    it('should throw NotFoundException if reservation not found', async () => {
+      // Arrange
+      mockContext.prisma.reservation.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.updateReservation('invalid_id', 'user1', {
+          numberOfGuests: 2,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteReservation', () => {
+    it('should delete existing reservation', async () => {
+      // Arrange
+      const mockReservation = {
+        id: 'res1',
+        propertyId: 'prop1',
+        userId: 'user1',
+        startDate: '2024-04-01',
+        endDate: '2024-04-03',
+        totalPrice: 600,
+        numberOfGuests: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockContext.prisma.reservation.findUnique.mockResolvedValue(
+        mockReservation,
+      );
+      mockContext.prisma.reservation.delete.mockResolvedValue(mockReservation);
+
+      // Act
+      const result = await service.deleteReservation('res1');
+
+      // Assert
+      expect(result).toEqual(mockReservation);
+      expect(mockContext.prisma.reservation.delete).toHaveBeenCalledWith({
+        where: { id: 'res1' },
+      });
+    });
+
+    it('should throw NotFoundException if reservation not found', async () => {
+      // Arrange
+      mockContext.prisma.reservation.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.deleteReservation('invalid_id')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/apps/main-service/src/domain/user/user.service.spec.ts
+++ b/apps/main-service/src/domain/user/user.service.spec.ts
@@ -1,0 +1,127 @@
+import { UserService } from './user.service';
+import { createTestingModule } from '../../test/test-utils';
+import { MockContext } from '../../database/database.service.test';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import bcrypt from 'bcrypt';
+
+jest.mock('bcrypt');
+
+describe('UserService', () => {
+  let service: UserService;
+  let mockContext: MockContext;
+
+  beforeEach(async () => {
+    const { module, mockContext: mc } = await createTestingModule([
+      UserService,
+    ]);
+    service = module.get<UserService>(UserService);
+    mockContext = mc;
+  });
+
+  describe('create', () => {
+    it('should create user with valid data', async () => {
+      // Arrange
+      const mockUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        username: 'testuser',
+        firstName: 'Test',
+        lastName: 'User',
+        password: 'hashedPassword',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockContext.prisma.user.findUnique.mockResolvedValue(null);
+      mockContext.prisma.user.create.mockResolvedValue(mockUser);
+      (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashedPassword');
+
+      // Act
+      const result = await service.create({
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'password123',
+        password2: 'password123',
+        firstName: 'Test',
+        lastName: 'User',
+      });
+
+      // Assert
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw BadRequestException if email exists', async () => {
+      // Arrange
+      mockContext.prisma.user.findUnique.mockResolvedValue({
+        id: 'existingUser',
+        email: 'test@example.com',
+        username: 'existinguser',
+        password: 'hashedpass',
+        firstName: 'Existing',
+        lastName: 'User',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      // Act & Assert
+      await expect(
+        service.create({
+          email: 'test@example.com',
+          username: 'testuser',
+          password: 'password123',
+          password2: 'password123',
+          firstName: 'Test',
+          lastName: 'User',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('should reset password with valid data', async () => {
+      // Arrange
+      const mockUser = {
+        id: 'user1',
+        email: 'test@example.com',
+        username: 'testuser',
+        password: 'hashedpass',
+        firstName: 'Test',
+        lastName: 'User',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockContext.prisma.user.findUnique.mockResolvedValue(mockUser);
+      mockContext.prisma.user.update.mockResolvedValue(mockUser);
+      (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('newHashedPassword');
+
+      // Act
+      const result = await service.resetPassword({
+        email: 'test@example.com',
+        username: 'testuser',
+        newPassword: 'newpassword',
+        confirmNewPassword: 'newpassword',
+      });
+
+      // Assert
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should throw NotFoundException if user not found', async () => {
+      // Arrange
+      mockContext.prisma.user.findUnique.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.resetPassword({
+          email: 'nonexistent@example.com',
+          username: 'testuser',
+          newPassword: 'newpassword',
+          confirmNewPassword: 'newpassword',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/main-service/src/test/test-utils.ts
+++ b/apps/main-service/src/test/test-utils.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DatabaseService } from '../database/database.service';
+import {
+  createMockContext,
+  MockContext,
+} from '../database/database.service.test';
+
+export const createTestingModule = async (providers: any[]) => {
+  let mockContext: MockContext;
+
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ...providers,
+      {
+        provide: DatabaseService,
+        useFactory: () => {
+          mockContext = createMockContext();
+          return mockContext.prisma;
+        },
+      },
+    ],
+  }).compile();
+
+  return { module, mockContext };
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: '.',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: './coverage',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/apps/'],
+  moduleNameMapper: {
+    '^@app/(.*)$': '<rootDir>/apps/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/apps/naturenest-backend/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test": "jest --config jest.config.js",
+    "test:watch": "jest --config jest.config.js --watch",
+    "test:cov": "jest --config jest.config.js --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./apps/naturenest-backend/test/jest-e2e.json",
     "migration:generate": "dotenv -e apps/main-service/.env npx prisma migrate dev",
@@ -60,6 +60,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^9.1.7",
     "jest": "29.7.0",
+    "jest-mock-extended": "^4.0.0-beta1",
     "lint-staged": "^15.2.11",
     "prettier": "^2.3.2",
     "source-map-support": "^0.5.20",
@@ -69,25 +70,5 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "4.2.0",
     "typescript": "^5.7.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": ".",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "./coverage",
-    "testEnvironment": "node",
-    "roots": [
-      "<rootDir>/apps/"
-    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3734,6 +3734,13 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock-extended@^4.0.0-beta1:
+  version "4.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz#7da4e10906b5736f6e76e3dca9395f7a0ff2bcce"
+  integrity sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==
+  dependencies:
+    ts-essentials "^10.0.2"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
@@ -5291,16 +5298,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5341,14 +5339,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5546,6 +5537,11 @@ ts-api-utils@^1.3.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
+
+ts-essentials@^10.0.2:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-10.0.3.tgz#5a5546f00aae2368b47b4f0f6572e2cd6b423f33"
+  integrity sha512-/FrVAZ76JLTWxJOERk04fm8hYENDo0PWSP3YLQKxevLwWtxemGcl5JJEzN4iqfDlRve0ckyfFaOBu4xbNH/wZw==
 
 ts-jest@29.2.5:
   version "29.2.5"
@@ -5830,7 +5826,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5843,15 +5839,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Add test utilities and mock setup
- Add tests for AuthService (login, register)
- Add tests for UserService (create, reset password)
- Add tests for CategoryService (init, pagination)
- Add tests for AmenityService (init, pagination)
- Add tests for PropertyService (CRUD operations)
- Add tests for ReservationService (booking flow)

All tests use mock database to prevent affecting real data. Tests cover main functionality and error cases.